### PR TITLE
Modify `jco types` command to accept a configuration file

### DIFF
--- a/crates/js-component-bindgen-component/src/lib.rs
+++ b/crates/js-component-bindgen-component/src/lib.rs
@@ -64,18 +64,8 @@ export!(JsComponentBindgenComponent);
 impl Guest for JsComponentBindgenComponent {
     fn generate(component: Vec<u8>, options: GenerateOptions) -> Result<Transpiled, String> {
         let component = wat::parse_bytes(&component).map_err(|e| format!("{e}"))?;
-        let configuration = match &options.configuration_file {
-            Some(path) => {
-                let contents = std::fs::read_to_string(path)
-                    .with_context(|| format!("failed to read configuration file {path}"))
-                    .map_err(|e| e.to_string())?;
-                let configuration: js_component_bindgen::configuration::Configuration =
-                    serde_json::from_str(&contents).map_err(|e| e.to_string())?;
-                println!("{:?}", configuration);
-                configuration
-            }
-            None => Default::default(),
-        };
+
+        let configuration = get_configuration(&options.configuration_file)?;
         let opts = js_component_bindgen::TranspileOpts {
             name: options.name,
             no_typescript: options.no_typescript.unwrap_or(false),
@@ -130,19 +120,8 @@ impl Guest for JsComponentBindgenComponent {
         opts: TypeGenerationOptions,
     ) -> Result<Vec<(String, Vec<u8>)>, String> {
         let mut resolve = Resolve::default();
-        let configuration = match &opts.configuration_file {
-            Some(path) => {
-                let contents = std::fs::read_to_string(path)
-                    .with_context(|| format!("failed to read configuration file {path}"))
-                    .map_err(|e| e.to_string())?;
-                let configuration: js_component_bindgen::configuration::Configuration =
-                    serde_json::from_str(&contents).map_err(|e| e.to_string())?;
-                println!("{:?}", configuration);
-                configuration
-            }
-            None => Default::default(),
-        };
 
+        let configuration = get_configuration(&opts.configuration_file)?;
         let id = match opts.wit {
             Wit::Source(source) => {
                 let pkg = UnresolvedPackage::parse(&PathBuf::from(format!("{name}.wit")), &source)
@@ -192,5 +171,22 @@ impl Guest for JsComponentBindgenComponent {
         let files = generate_types(name, resolve, world, opts).map_err(|e| e.to_string())?;
 
         Ok(files)
+    }
+}
+
+fn get_configuration(
+    config_file: &Option<String>,
+) -> Result<js_component_bindgen::configuration::Configuration, String> {
+    match config_file {
+        Some(path) => {
+            let contents = std::fs::read_to_string(path)
+                .with_context(|| format!("failed to read configuration file {path}"))
+                .map_err(|e| e.to_string())?;
+            let configuration: js_component_bindgen::configuration::Configuration =
+                serde_json::from_str(&contents).map_err(|e| e.to_string())?;
+            println!("{:?}", configuration);
+            Ok(configuration)
+        }
+        None => Ok(Default::default()),
     }
 }

--- a/crates/js-component-bindgen-component/src/lib.rs
+++ b/crates/js-component-bindgen-component/src/lib.rs
@@ -130,6 +130,19 @@ impl Guest for JsComponentBindgenComponent {
         opts: TypeGenerationOptions,
     ) -> Result<Vec<(String, Vec<u8>)>, String> {
         let mut resolve = Resolve::default();
+        let configuration = match &opts.configuration_file {
+            Some(path) => {
+                let contents = std::fs::read_to_string(path)
+                    .with_context(|| format!("failed to read configuration file {path}"))
+                    .map_err(|e| e.to_string())?;
+                let configuration: js_component_bindgen::configuration::Configuration =
+                    serde_json::from_str(&contents).map_err(|e| e.to_string())?;
+                println!("{:?}", configuration);
+                configuration
+            }
+            None => Default::default(),
+        };
+
         let id = match opts.wit {
             Wit::Source(source) => {
                 let pkg = UnresolvedPackage::parse(&PathBuf::from(format!("{name}.wit")), &source)
@@ -172,7 +185,7 @@ impl Guest for JsComponentBindgenComponent {
             tracing: false,
             no_namespaced_exports: false,
             multi_memory: false,
-            configuration: Default::default(),
+            configuration,
             import_bindings: None,
         };
 

--- a/crates/js-component-bindgen-component/src/lib.rs
+++ b/crates/js-component-bindgen-component/src/lib.rs
@@ -175,9 +175,9 @@ impl Guest for JsComponentBindgenComponent {
 }
 
 fn get_configuration(
-    config_file: &Option<String>,
+    config_file_path: &Option<String>,
 ) -> Result<js_component_bindgen::configuration::Configuration, String> {
-    match config_file {
+    match config_file_path {
         Some(path) => {
             let contents = std::fs::read_to_string(path)
                 .with_context(|| format!("failed to read configuration file {path}"))

--- a/crates/js-component-bindgen-component/wit/js-component-bindgen.wit
+++ b/crates/js-component-bindgen-component/wit/js-component-bindgen.wit
@@ -84,6 +84,9 @@ world js-component-bindgen {
     tla-compat: option<bool>,
     instantiation: option<instantiation-mode>,
     map: option<maps>,
+
+    /// The path to a json5 configuration file to use for the code generation
+    configuration-file: option<string>,
   }
 
   enum export-type {

--- a/crates/js-component-bindgen/src/ts_bindgen.rs
+++ b/crates/js-component-bindgen/src/ts_bindgen.rs
@@ -1043,13 +1043,16 @@ impl<'a> TsInterface<'a> {
             .get(&self.resolve, &id)
             .enum_as_typescript_enum()
         {
+            if let Some(docs) = &docs.contents {
+                self.docs_raw(docs);
+            }
             self.src.push_str(&format!(
                 "export declare enum {} {{\n",
                 name.to_upper_camel_case()
             ));
             for case in enum_.cases.iter() {
                 if let Some(docs) = &case.docs.contents {
-                    self.src.push_str(docs);
+                    self.docs_raw(docs);
                 }
                 let name = case.name.to_upper_camel_case();
                 self.src.push_str(&format!("{name} = '{name}',\n",));

--- a/src/cmd/transpile.js
+++ b/src/cmd/transpile.js
@@ -27,6 +27,7 @@ export async function types(witPath, opts) {
  *   instantiation?: 'async' | 'sync',
  *   tlaCompat?: bool,
  *   outDir?: string,
+ *   configurationFile?: string,
  * }} opts
  * @returns {Promise<{ [filename: string]: Uint8Array }>}
  */
@@ -46,7 +47,8 @@ export async function typesComponent(witPath, opts) {
     wit: { tag: 'path', val: (isWindows ? '//?/' : '') + resolve(witPath) },
     instantiation,
     tlaCompat: opts.tlaCompat ?? false,
-    world: opts.worldName
+    world: opts.worldName,
+    configurationFile: opts.configurationFile,
   }).map(([name, file]) => [`${outDir}${name}`, file]));
 }
 

--- a/src/jco.js
+++ b/src/jco.js
@@ -63,6 +63,7 @@ program.command('types')
   .option('-n, --world-name <world>', 'WIT world to generate types for')
   .requiredOption('-o, --out-dir <out-dir>', 'output directory')
   .option('--tla-compat', 'generates types for the TLA compat output with an async $init promise export')
+  .option('--configuration-file <filename>', 'the path to a json5 configuration file to use for the code generation')
   .addOption(new Option('-I, --instantiation [mode]', 'type output for custom module instantiation').choices(['async', 'sync']).preset('async'))
   .option('-q, --quiet', 'disable output summary')
   .action(asyncAction(types));


### PR DESCRIPTION
This PR modifies the command `jco types` so that it accepts the same configuration file accepted by `jco transpile`.

We need to use `jco types` to generate Typescript interfaces because this command uses the .wit source files to create types, while `jco transpile` creates types by decoding the compiled WASM code. These binaries don't contain any documentation, so it wasn't available to output to `*.d.ts`.

Without the configuration file, we aren't able to customize the Typescript interface. The key thing that we're missing here is the ability to output Rust enums as Typescript enums.

This PR also includes a quick update to `TsBindgen#type_enum` so that it outputs doc comments for Typescript enum types.