### PR TITLE
Escape the multiline-comment end sequence '*/' in doc comments

### DIFF
--- a/crates/js-component-bindgen/src/ts_bindgen.rs
+++ b/crates/js-component-bindgen/src/ts_bindgen.rs
@@ -552,7 +552,8 @@ impl<'a> TsInterface<'a> {
     fn docs_raw(&mut self, docs: &str) {
         self.src.push_str("/**\n");
         for line in docs.lines() {
-            self.src.push_str(&format!(" * {}\n", line));
+            self.src
+                .push_str(&format!(" * {}\n", line.replace("*/", "*\\/")));
         }
         self.src.push_str(" */\n");
     }


### PR DESCRIPTION
This fixes an issue I encountered when adding EBNF documentation to the TerminalKind and NonterminalKind enums. The TerminalKind variants "MultilineComment" and "MultiLineNatSpecComment" both print out the sequence "*/", but this sequence ends the current doc comment and then causes the rest of the file to be parsed incorrectly. By escaping this sequence we avoid this issue, but the generated docs still show the correct string.

The escaped sequence looks like this: '*\/'.