### PR TITLE
Update default target

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,8 +23,8 @@ jobs:
       run: rustup update stable --no-self-update && rustup default stable
     - name: Install wasm32-unknown-unknown target
       run: rustup target add wasm32-unknown-unknown
-    - name: Install wasm32-wasi target
-      run: rustup target add wasm32-wasi
+    - name: Install wasm32-wasip1 target
+      run: rustup target add wasm32-wasip1
     - name: Install NPM packages
       run: npm install
     - name: Build
@@ -96,9 +96,9 @@ jobs:
     - name: Install wasm32-unknown-unknown target
       if: steps.cache-wasi-tests.outputs.cache-hit != 'true'
       run: rustup target add wasm32-unknown-unknown
-    - name: Install wasm32-wasi target
+    - name: Install wasm32-wasip1 target
       if: steps.cache-wasi-tests.outputs.cache-hit != 'true'
-      run: rustup target add wasm32-wasi
+      run: rustup target add wasm32-wasip1
     - name: Install wasm-tools
       if: steps.cache-wasi-tests.outputs.cache-hit != 'true'
       run: cargo install wasm-tools

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -10,7 +10,7 @@ Specific tests can be run adding the mocha `--grep` / `-g` flag, for example: `n
 
 Required prerequisites for building jco include:
 
-* [Latest stable Rust](https://www.rust-lang.org/tools/install) with the `wasm32-wasi` target
+* [Latest stable Rust](https://www.rust-lang.org/tools/install) with the `wasm32-wasip1` target
 * Node.js 18+ & npm (https://nodejs.org/en)
 
 ### Rust Toolchain
@@ -21,7 +21,7 @@ Specifically:
 
 ```shell
 rustup toolchain install stable
-rustup target add wasm32-wasi
+rustup target add wasm32-wasip1
 ```
 
 In case you do not have `rustup` installed on your system, please follow the installation instructions on the [official Rust website](https://www.rust-lang.org/tools/install) based on your operating system

--- a/xtask/src/build/jco.rs
+++ b/xtask/src/build/jco.rs
@@ -7,12 +7,12 @@ use xshell::{cmd, Shell};
 pub(crate) fn run(release: bool) -> Result<()> {
     let build = if release { "release" } else { "debug" };
     transpile(
-        &format!("target/wasm32-wasi/{build}/js_component_bindgen_component.wasm"),
+        &format!("target/wasm32-wasip1/{build}/js_component_bindgen_component.wasm"),
         "js-component-bindgen-component".to_string(),
         release,
     )?;
     transpile(
-        &format!("target/wasm32-wasi/{build}/wasm_tools_js.wasm"),
+        &format!("target/wasm32-wasip1/{build}/wasm_tools_js.wasm"),
         "wasm-tools".to_string(),
         release,
     )?;

--- a/xtask/src/build/workspace.rs
+++ b/xtask/src/build/workspace.rs
@@ -3,9 +3,13 @@ use xshell::{cmd, Shell};
 pub(crate) fn run(release: bool) -> anyhow::Result<()> {
     let sh = Shell::new()?;
     if release {
-        cmd!(sh, "cargo build --workspace --release --target wasm32-wasi").read()?;
+        cmd!(
+            sh,
+            "cargo build --workspace --release --target wasm32-wasip1"
+        )
+        .read()?;
     } else {
-        cmd!(sh, "cargo build --workspace --target wasm32-wasi").read()?;
+        cmd!(sh, "cargo build --workspace --target wasm32-wasip1").read()?;
     }
     cmd!(sh, "node node_modules/typescript/bin/tsc -p tsconfig.json").read()?;
     sh.copy_file(

--- a/xtask/src/generate/tests.rs
+++ b/xtask/src/generate/tests.rs
@@ -73,7 +73,7 @@ pub fn run() -> anyhow::Result<()> {
 
     // Compile wasmtime test programs
     let guard = sh.push_dir("submodules/wasmtime/crates/test-programs");
-    cmd!(sh, "cargo build --target wasm32-wasi").run()?;
+    cmd!(sh, "cargo build --target wasm32-wasip1").run()?;
     drop(guard);
 
     // Tidy up the dir and recreate it.
@@ -85,7 +85,7 @@ pub fn run() -> anyhow::Result<()> {
 
     let mut test_names = vec![];
 
-    for entry in fs::read_dir("submodules/wasmtime/target/wasm32-wasi/debug")? {
+    for entry in fs::read_dir("submodules/wasmtime/target/wasm32-wasip1/debug")? {
         let entry = entry?;
         // skip all files which don't end with `.wasm`
         if entry.path().extension().and_then(|p| p.to_str()) != Some("wasm") {
@@ -111,7 +111,7 @@ pub fn run() -> anyhow::Result<()> {
 
     let mut all_names = Vec::new();
     for test_name in test_names {
-        let path = format!("submodules/wasmtime/target/wasm32-wasi/debug/{test_name}.wasm");
+        let path = format!("submodules/wasmtime/target/wasm32-wasip1/debug/{test_name}.wasm");
         // compile into generated dir
         let dest_file = format!("./tests/gen/{test_name}.component.wasm");
 


### PR DESCRIPTION
Fixes an issue introduced since the target `wasm32-wasi` was deprecated. All occurrences of `wasm32-wasi` have been replaced with `wasm32-wasip1`.